### PR TITLE
TEST: Revise README stderr doctest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ script:
  - python --version
  - pip list
  - minor_version=$( echo $TRAVIS_PYTHON_VERSION | sed -E 's/^[^3]*3[.]([0-9]+).*$/\1/' )
- - if [ $minor_version -eq 8 ]; then pytest -k _base; else pytest --cov=src; fi
+ - pytest --cov=src
  - if [ $minor_version -eq 6 ]; then codecov; else echo "No codecov."; fi
  - if [ $minor_version -eq 6 ]; then pip install black; black --check .; else echo "No black."; fi

--- a/README.rst
+++ b/README.rst
@@ -81,10 +81,10 @@ upon exiting the managed context.
 
     >>> import warnings
     >>> with stdio_mgr() as (in_, out_, err_):
-    ...     warnings.warn("'foo' has no 'bar'")
+    ...     warnings.warn("foo has no bar")
     ...     err_cap = err_.getvalue()
     >>> err_cap
-    "...UserWarning: 'foo' has no 'bar'\n..."
+    '...UserWarning: foo has no bar\n...'
 
 
 **Mock** ``stdin``\ **:**

--- a/tox.ini
+++ b/tox.ini
@@ -2,18 +2,20 @@
 minversion=2.0
 isolated_build=True
 envlist=
-    py3{4,5,6,7}-attrs_{17_4,18_2}
+    py3{4,5,6,7,8}-attrs_{17_4,18_2}
     py36-attrs_{17_1,17_2,17_3,18_1,latest}
     py33-attrs_17_3
     py37-attrs_latest
+    py38-attrs_latest
     sdist_install
 
 [testenv]
 commands=
     #python --version
     #python tests.py -a
-    py3{4,5,6,7}:   pytest
-    py38:           pytest -k _base
+    #py3{4,5,6,7}:   pytest
+    #py38:           pytest -k _base
+    pytest
 deps=
     attrs_17_1:     attrs==17.1
     attrs_17_2:     attrs==17.2


### PR DESCRIPTION
Per here (https://bugs.python.org/issue36695), having single quotes
in the warning message for the stderr README doctest led to
different result rendering in 3.7 vs 3.8. Removing those quotes
from the message eliminates the breakage.