### PR TITLE
ADMIN: Fix spurious complexity in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os.path as osp
 from setuptools import setup, find_packages
 
 
-with open(osp.join(*["src", "stdio_mgr", "version.py"])) as f:
+with open(osp.join("src", "stdio_mgr", "version.py")) as f:
     exec(f.read())
 
 


### PR DESCRIPTION
Don't need to unpack a list literal--just pass directly as separate arguments.

Closes #22.