### PR TITLE
ADMIN: Buff flake8 and add to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 dist: xenial
 install:
+ - PYTHON_MAJOR=$( python -c 'import sys; print(sys.version_info.major)' )
+ - PYTHON_MINOR=$( python -c 'import sys; print(sys.version_info.minor)' )
+ - pip install -U pip setuptools
  - pip install -U --force-reinstall -r requirements-travis.txt
+ - if (( ( $PYTHON_MAJOR > 3 ) || ( $PYTHON_MAJOR == 3 && $PYTHON_MINOR >= 6 ) )); then pip install -r requirements-flake8.txt; fi
 language: python
 python:
  - 3.4
@@ -11,7 +15,6 @@ python:
 script:
  - python --version
  - pip list
- - minor_version=$( echo $TRAVIS_PYTHON_VERSION | sed -E 's/^[^3]*3[.]([0-9]+).*$/\1/' )
  - pytest --cov=src
- - if [ $minor_version -eq 6 ]; then codecov; else echo "No codecov."; fi
- - if [ $minor_version -eq 6 ]; then pip install black; black --check .; else echo "No black."; fi
+ - if (( $PYTHON_MAJOR == 3 && $PYTHON_MINOR == 7 )); then tox -e flake8; else echo "No flake8."; fi
+ - if (( $PYTHON_MAJOR == 3 && $PYTHON_MINOR == 7 )); then codecov; else echo "No codecov."; fi

--- a/conftest.py
+++ b/conftest.py
@@ -33,4 +33,5 @@ from stdio_mgr import stdio_mgr
 
 @pytest.fixture(autouse=True)
 def add_stdio_mgr(doctest_namespace):
+    """Add stdio_mgr to doctest namespace."""
     doctest_namespace["stdio_mgr"] = stdio_mgr

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,5 @@
 attrs>=17
 black
-flake8==3.4.1
-flake8-docstrings==1.1.0
 pytest
 pytest-cov
 restview
@@ -9,3 +7,4 @@ tox
 twine
 wget
 -e .
+-r requirements-flake8.txt

--- a/requirements-flake8.txt
+++ b/requirements-flake8.txt
@@ -1,0 +1,14 @@
+flake8>=3.7
+flake8-bandit
+flake8-black
+flake8-bugbear
+flake8-builtins
+flake8-colors
+flake8-comprehensions
+flake8-docstrings
+flake8-eradicate
+flake8-import-order
+flake8-pie
+flake8-rst-docstrings
+pep8-naming
+pydocstyle<4

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -2,4 +2,5 @@ attrs>=17
 codecov
 pytest
 pytest-cov
+tox
 -e .

--- a/tox.ini
+++ b/tox.ini
@@ -5,16 +5,11 @@ envlist=
     py3{4,5,6,7,8}-attrs_{17_4,18_2}
     py36-attrs_{17_1,17_2,17_3,18_1,latest}
     py33-attrs_17_3
-    py37-attrs_latest
-    py38-attrs_latest
+    py3{7,8}-attrs_latest
     sdist_install
 
 [testenv]
 commands=
-    #python --version
-    #python tests.py -a
-    #py3{4,5,6,7}:   pytest
-    #py38:           pytest -k _base
     pytest
 deps=
     attrs_17_1:     attrs==17.1
@@ -52,5 +47,32 @@ basepython=
 commands=
     python -c "import stdio_mgr"
 
+[testenv:flake8]
+skip_install=True
+whitelist_externals=flake8
+deps=
+commands=
+    flake8 conftest.py tests src
+
 [pytest]
 addopts = -p no:warnings --doctest-glob="README.rst"
+
+
+[flake8]
+# W503: black formats binary operators to start of line
+# RST30[456]: sphinx &c. have lots of custom roles; use '$ make html O=-n' to find typos
+ignore = W503,RST304,RST305,RST306
+show_source = True
+max_line_length = 88
+format = ${cyan}%(path)s${reset}:${yellow}%(row)d${reset}:${green}%(col)d${reset} ${red}(%(code)s)${reset} %(text)s
+per_file_ignores =
+# S101: pytest uses asserts liberally
+# S322: input() is ok on Python 3
+  tests/*:     S101,S322
+  conftest.py: S101,S322
+# F401: MANY things imported but unused in __init__,py
+  src/stdio_mgr/__init__.py:  F401
+
+#flake8-import-order
+import-order-style = smarkets
+application-import-names = stdio_mgr


### PR DESCRIPTION
- Update Travis config to better Python version scrape
- Add raft of flake8 plugins and config
- Add divided flake8 requirements install to -dev and -travis
- Add flake8 config and flake8 run environment to tox.ini
- Add docstring to conftest.py function (per flake8)

Temporary pin of pydocstyle<4, due to removal of function
depended on by flake8-docstrings; see
https://gitlab.com/pycqa/flake8-docstrings/issues/36

Closes #27.