### PR TITLE
Restore TeeStdin.getvalue() ValueError

### DIFF
--- a/src/stdio_mgr/stdio_mgr.py
+++ b/src/stdio_mgr/stdio_mgr.py
@@ -149,6 +149,8 @@ class TeeStdin(TextIOWrapper):
 
     def getvalue(self):
         """Obtain pending buffer of text for stdin."""
+        if self.closed:  # Triggers a ValueError if detached
+            self.read()  # Triggers a ValueError
         return self.buffer.peek().decode(self.encoding)
 
 

--- a/tests/test_stdiomgr_base.py
+++ b/tests/test_stdiomgr_base.py
@@ -29,6 +29,7 @@ interactions.
 
 import warnings
 
+import pytest
 
 from stdio_mgr import stdio_mgr
 
@@ -114,8 +115,29 @@ def test_repeated_use():
         test_capture_stderr()
 
 
+def test_stdin_closed():
+    """Confirm stdin's buffer can be closed within the context."""
+    with stdio_mgr() as (i, o, e):
+        print("test str")
+
+        i.close()
+
+        with pytest.raises(ValueError) as err:
+            i.getvalue()
+
+        assert str(err.value) == "I/O operation on closed file."
+
+        assert "test str\n" == o.getvalue()
+
+
 def test_stdin_detached():
     """Confirm stdin's buffer can be detached within the context."""
     with stdio_mgr() as (i, o, e):
         f = i.detach()
+
+        with pytest.raises(ValueError) as err:
+            i.getvalue()
+
+        assert str(err.value) == "underlying buffer has been detached"
+
     assert not f.closed


### PR DESCRIPTION
Prior to 3e8eb59033, TeeStdin.getvalue raised a ValueError
if the input stream was closed.

That change transformed it to a confusing AttributeError.

Restore the ValueError, and raise ValueError when stream is detached.