### PR TITLE
Restore state before propogating exception

### DIFF
--- a/src/stdio_mgr/stdio_mgr.py
+++ b/src/stdio_mgr/stdio_mgr.py
@@ -292,11 +292,12 @@ def stdio_mgr(in_str="", close=True):
     sys.stdout = new_stdout
     sys.stderr = new_stderr
 
-    yield new_stdin, new_stdout, new_stderr
+    try:
+        yield new_stdin, new_stdout, new_stderr
+    finally:
+        sys.stdin = old_stdin
+        sys.stdout = old_stdout
+        sys.stderr = old_stderr
 
-    sys.stdin = old_stdin
-    sys.stdout = old_stdout
-    sys.stderr = old_stderr
-
-    if close:
-        close_files()
+        if close:
+            close_files()

--- a/tests/test_stdiomgr_base.py
+++ b/tests/test_stdiomgr_base.py
@@ -27,6 +27,7 @@ interactions.
 """
 
 import io
+import sys
 import warnings
 
 import pytest
@@ -113,6 +114,22 @@ def test_repeated_use():
 
         # Tests stderr
         test_capture_stderr()
+
+
+def test_noop():
+    """Confirm state is restored after context."""
+    real_sys_stdio = (sys.stdin, sys.stdout, sys.stderr)
+    stdio_mgr()
+    assert (sys.stdin, sys.stdout, sys.stderr) == real_sys_stdio
+
+
+def test_exception():
+    """Confirm state is restored after an exception during context."""
+    real_sys_stdio = (sys.stdin, sys.stdout, sys.stderr)
+    with pytest.raises(ZeroDivisionError):
+        with stdio_mgr() as (i, o, e):
+            1 / 0
+    assert (sys.stdin, sys.stdout, sys.stderr) == real_sys_stdio
 
 
 def test_manual_close():


### PR DESCRIPTION
An exception during the context should not be caught, however
the previous state needs to be restored before exception propagates.

Fixes https://github.com/bskinn/stdio-mgr/issues/45