### PR TITLE
TEST: Add test & config exposing real warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ python:
 script:
  - python --version
  - pip list
- - pytest --cov=src
+ - pytest --cov=src -p no:warnings
  - if (( $PYTHON_MAJOR == 3 && $PYTHON_MINOR == 7 )); then tox -e flake8; else echo "No flake8."; fi
  - if (( $PYTHON_MAJOR == 3 && $PYTHON_MINOR == 7 )); then codecov; else echo "No codecov."; fi

--- a/azure-job.yml
+++ b/azure-job.yml
@@ -12,16 +12,16 @@ jobs:
             image_name: ${{ coalesce(image, 'linux') }}
             ${{ if eq(image, 'linux') }}:
               image: 'Ubuntu-16.04'
-              pytest_args: --doctest-glob="README.rst"
+              pytest_args: --doctest-glob="README.rst" -p no:warnings
             ${{ if eq(image, 'windows') }}:
               image: 'windows-2019'
-              pytest_args:
+              pytest_args: -p no:warnings
             ${{ if eq(image, 'macOs') }}:
               image: 'macOS-10.14'
-              pytest_args: --doctest-glob="README.rst"
+              pytest_args: --doctest-glob="README.rst" -p no:warnings
             ${{ if notIn(image, 'macOs', 'linux', 'windows') }}:
               image: ${{ coalesce(image, 'Ubuntu-16.04') }}
-              pytest_args: --doctest-glob="README.rst"
+              pytest_args: --doctest-glob="README.rst" -p no:warnings
 
     pool:
       vmImage: $[ variables.image ]
@@ -36,5 +36,5 @@ jobs:
       - script: pip install -r requirements-ci.txt
         displayName: Install CI requirements
 
-      - script: pytest -v $(pytest_args)
+      - script: pytest $(pytest_args)
         displayName: Run pytest (Python ${{ python.value.spec }})

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,3 +37,21 @@ jobs:
 
     - script: flake8 conftest.py src tests
       displayName: Lint the codebase
+
+# This job runs the test suite, skipping any tests that
+# intentionally raise warnings as part of their intended
+# behavior, and reporting any warnings that are emitted
+# unintentionally due to actual problems in the code.
+- job: expose_warnings
+  pool:
+    vmImage: 'Ubuntu-16.04'
+  steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.7'
+
+    - script: pip install -r requirements-ci.txt
+      displayName: Install CI requirements
+
+    - script: pytest -v -W error::Warning --skipwarnings
+      displayName: Run pytest, exposing underlying warnings (Python 3.7)

--- a/conftest.py
+++ b/conftest.py
@@ -33,6 +33,21 @@ import pytest
 from stdio_mgr import stdio_mgr
 
 
+def pytest_addoption(parser):
+    """Add custom CLI options to pytest."""
+    parser.addoption(
+        "--skipwarnings",
+        action="store_true",
+        help=("Skip tests that intentionally raise warnings"),
+    )
+
+
+@pytest.fixture(scope="session")
+def skip_warnings(pytestconfig):
+    """Provide concise access to '--skipwarnings' CLI option."""
+    return pytestconfig.getoption("--skipwarnings")
+
+
 @pytest.fixture(autouse=True)
 def add_stdio_mgr(doctest_namespace):
     """Add stdio_mgr to doctest namespace."""

--- a/tests/test_stdiomgr_base.py
+++ b/tests/test_stdiomgr_base.py
@@ -45,8 +45,11 @@ def test_capture_stdout(convert_newlines):
         assert convert_newlines(s + "\n") == o.getvalue()
 
 
-def test_capture_stderr(convert_newlines):
+def test_capture_stderr(convert_newlines, skip_warnings):
     """Confirm stderr capture."""
+    if skip_warnings:
+        pytest.skip("Skip warning tests")
+
     with stdio_mgr() as (i, o, e):
         w = "This is a warning"
 
@@ -106,14 +109,15 @@ def test_managed_stdin(convert_newlines):
         assert convert_newlines(str2[:-1]) == out_str
 
 
-def test_repeated_use(convert_newlines):
+def test_repeated_use(convert_newlines, skip_warnings):
     """Confirm repeated stdio_mgr use works correctly."""
     for _ in range(4):
         # Tests both stdin and stdout
         test_default_stdin(convert_newlines)
 
         # Tests stderr
-        test_capture_stderr(convert_newlines)
+        if not skip_warnings:
+            test_capture_stderr(convert_newlines, skip_warnings)
 
 
 def test_noop():
@@ -132,11 +136,13 @@ def test_exception():
     assert (sys.stdin, sys.stdout, sys.stderr) == real_sys_stdio
 
 
-def test_manual_close(convert_newlines):
+def test_manual_close(convert_newlines, skip_warnings):
     """Confirm files remain open if close=False after the context has exited."""
     with stdio_mgr(close=False) as (i, o, e):
         test_default_stdin(convert_newlines)
-        test_capture_stderr(convert_newlines)
+
+        if not skip_warnings:
+            test_capture_stderr(convert_newlines, skip_warnings)
 
     assert not i.closed
     assert not o.closed
@@ -147,11 +153,13 @@ def test_manual_close(convert_newlines):
     e.close()
 
 
-def test_manual_close_detached_fails(convert_newlines):
+def test_manual_close_detached_fails(convert_newlines, skip_warnings):
     """Confirm files kept open become unusable after being detached."""
     with stdio_mgr(close=False) as (i, o, e):
         test_default_stdin(convert_newlines)
-        test_capture_stderr(convert_newlines)
+
+        if not skip_warnings:
+            test_capture_stderr(convert_newlines, skip_warnings)
 
         i.detach()
         o.detach()
@@ -338,3 +346,22 @@ def test_stdout_access_buffer_after_close(convert_newlines):
         assert convert_newlines("test str\nsecond test str\n") == o.getvalue()
 
     assert convert_newlines("test str\nsecond test str\n") == o.getvalue()
+
+
+@pytest.mark.xfail(reason="Want to ensure 'real' warnings aren't suppressed")
+def test_bare_warning(skip_warnings):
+    """Test that a "real" warning is exposed when raised."""
+    from enum import Enum
+
+    # skip_warnings=True implies that pytest is being run with warning
+    # reporting ENABLED. So, proceed to warning test.
+    # skip_warnings=False implies that pytest is being run with
+    # -p no:warnings, and thus the below warning will be suppressed.
+    # Thus, for the latter case, a forced fail is appropriate
+    assert skip_warnings
+
+    class Foo(Enum):
+        One = 1
+        Two = 2
+
+    "foo" in Foo

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,8 @@ commands=
     flake8 conftest.py tests src
 
 [pytest]
-addopts = -p no:warnings
+addopts = -v -rsxX
+xfail_strict = True
 
 
 [flake8]


### PR DESCRIPTION
Previously, the test suite was run with pytest reporting of
warnings completely suppressed (-p no:warnings). This has the
potential to mask real warnings emitted by the underlying code.

This adds test machinery, including Azure CI, to expose any
such warnings that may arise.

Closes #50.

- Add Azure job running in emit-warnings mode
- Reconfigure main Azure template to accommodate the removal of
  '-p no:warnings' from the default options list
- Reconfigure .travis.yml to include explicit -p no:warnings
- Add pytest machinery to skip tests emitting intentional
  warnings when invoked with warnings reporting enabled
- Add new test intentionally emitting a "real" warning, set as
  XFAIL, to ensure warning reporting is actually happening
- Add reason-reporting for skip/XFAIL/XPASS to default config