### PR TITLE
ADMIN: Restore explicit py3.4 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 minversion=2.0
 isolated_build=True
 envlist=
-    py3{4,5,6,7,8}-attrs_{17_4,18_2}
-    py36-attrs_{17_1,17_2,17_3,18_1,latest}
-    py33-attrs_17_3
+    py3{3,4,5,6,7,8}-attrs_{17_4,18_2,19_1}
+    py36-attrs_{17_1,17_2,17_3,18_1,19_1,latest}
+    py3{3,4}-attrs_17_3
     py3{7,8}-attrs_latest
     sdist_install
 
@@ -18,6 +18,7 @@ deps=
     attrs_17_4:     attrs==17.4
     attrs_18_1:     attrs==18.1
     attrs_18_2:     attrs==18.2
+    attrs_19_1:     attrs==19.1
     attrs_latest:   attrs
 
     attrs_17_1:     pytest==3.2.5
@@ -42,6 +43,7 @@ basepython=
     py36: python3.6
     py35: python3.5
     py34: python3.4
+    py33: python3.3
 
 [testenv:sdist_install]
 commands=


### PR DESCRIPTION
Mostly in the setup.py classifiers.

Also readjust the tox environments a bit for newer attrs, and to allow non-CI checks for Python 3.3 compat.

Reverts #40 per [request from jayvdb](https://github.com/bskinn/stdio-mgr/issues/40#issuecomment-522882563).