### PR TITLE
Split TeeStdin to create superclass SimulateStdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### [Unreleased]
 
-...
+ * Removed use of `attrs`.
 
 ### [1.0.1] - 2019-02-11
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,3 @@
-attrs>=17
 codecov
 pytest
 pytest-cov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-attrs>=17
 black
 pytest
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,6 @@ setup(
     packages=find_packages("src"),
     package_dir={"": "src"},
     provides=["stdio_mgr"],
-    requires=["attrs (>=17.1)"],
-    install_requires=["attrs>=17.1"],
     python_requires=">=3.4",
     url="https://www.github.com/bskinn/stdio-mgr",
     license="MIT License",

--- a/src/stdio_mgr/stdio_mgr.py
+++ b/src/stdio_mgr/stdio_mgr.py
@@ -28,7 +28,15 @@ interactions.
 
 import sys
 from contextlib import ExitStack, suppress
-from io import BufferedRandom, BufferedReader, BytesIO, TextIOBase, TextIOWrapper
+from io import (
+    BufferedRandom,
+    BufferedReader,
+    BytesIO,
+    SEEK_END,
+    SEEK_SET,
+    TextIOBase,
+    TextIOWrapper,
+)
 
 # AbstractContextManager was introduced in Python 3.6
 # and may be used with typing.ContextManager.
@@ -36,8 +44,6 @@ try:
     from contextlib import AbstractContextManager
 except ImportError:  # pragma: no cover
     AbstractContextManager = object
-
-import attr
 
 
 class _PersistedBytesIO(BytesIO):
@@ -95,60 +101,31 @@ class RandomTextIO(TextIOWrapper):
             return self._stream.getvalue().decode(self.encoding)
 
 
-@attr.s(slots=False)
-class TeeStdin(TextIOWrapper):
+class _Tee(TextIOWrapper):
     """Class to tee contents to a side buffer on read.
 
     Subclass of :class:`~io.TextIOWrapper` that overrides
     :meth:`~io.TextIOBase.read` and :meth:`~io.TextIOBase.readline`
-    to tee all content *read* from the stream to `tee`. The
-    canonical use-case is with :func:`stdio_mgr`,
-    where `tee` is the mocked stream for `stdin`.
+    to tee all content *read* from the stream to `tee`.
 
     To emphasize: teeing occurs on content *read*, **not write**.
 
     As a subclass of :class:`~io.TextIOWrapper`, it is not thread-safe.
 
-    This class provides :meth:`~TeeStdin.getvalue` which emulates the
-    behavior of :meth:`StringIO.getvalue() <io.StringIO.getvalue>`,
-    decoding the buffer using the :attr:`~io.TextIOBase.encoding`.
-
-    This class also provides the method
-    :meth:`~TeeStdin.append`, which is not available
-    for the base :class:`TextIOWrapper <io.TextIOWrapper>` type.
-    This method adds new content to the end of the
-    stream while leaving the read position unchanged.
-
-    Instantiation takes two arguments:
+    Instantiation takes an additional argument:
 
     `tee`
 
-        :class:`~io.TextIOBase` -- Text stream to receive
-        content teed from :class:`TeeStdin` upon read
+        :class:`~io.TextIOBase` -- Text stream to write content of each read
 
-    `init_text`
-
-        |str| *(optional)* --
-        Text to use as the initial contents of the stream to be teed.
-        Default is an empty |str|.
-
-    `encoding`
-
-        |str| *(optional)* --
-        Encoding for the underlying :class:`~io.TextIOWrapper`.
-        Default is "utf-8".
     """
 
-    from io import SEEK_SET, SEEK_END
-
-    tee = attr.ib(validator=attr.validators.instance_of(TextIOBase))
-    init_text = attr.ib(default="", validator=attr.validators.instance_of(str))
-    _encoding = attr.ib(default="utf-8", validator=attr.validators.instance_of(str))
-
-    def __attrs_post_init__(self):
-        """Call normal __init__ on superclass."""
-        self._buf = BytesIO(self.init_text.encode(self._encoding))
-        super().__init__(BufferedReader(self._buf), encoding=self._encoding)
+    def __init__(self, tee, *args, **kwargs):
+        """Initialise attribute tee."""
+        super().__init__(*args, **kwargs)
+        if not isinstance(tee, TextIOBase):
+            raise ValueError("tee must be a TextIOBase.")
+        self.tee = tee
 
     def read(self, size=None):  # pragma: no cover
         """Tee text to side buffer when read.
@@ -188,6 +165,43 @@ class TeeStdin(TextIOWrapper):
         self.tee.write(text)
         return text
 
+
+class SimulateStdin(TextIOWrapper):
+    """Class to simulate content appearing on stdin.
+
+    Subclass of :class:`~io.TextIOWrapper` that
+    provides :meth:`~SimulateStdin.getvalue` which emulates the
+    behavior of :meth:`StringIO.getvalue() <io.StringIO.getvalue>`,
+    decoding the buffer using the :attr:`~io.TextIOBase.encoding`.
+
+    This class also provides the method
+    :meth:`~SimulateStdin.append`, which is not available
+    for the base :class:`TextIOWrapper <io.TextIOWrapper>` type.
+    This method adds new content to the end of the
+    stream while leaving the read position unchanged.
+
+    As a subclass of :class:`~io.TextIOWrapper`, it is not thread-safe.
+
+    Instantiation takes two arguments:
+
+    `init_text`
+
+        |str| *(optional)* --
+        Text to use as the initial contents of the stream to be teed.
+        Default is an empty |str|.
+
+    `encoding`
+
+        |str| *(optional)* --
+        Encoding for the underlying :class:`~io.TextIOWrapper`.
+        Default is "utf-8".
+    """
+
+    def __init__(self, init_text="", encoding="utf-8"):
+        """Initialise simulated buffer."""
+        self._buf = BytesIO(init_text.encode(encoding))
+        super().__init__(BufferedReader(self._buf), encoding=encoding)
+
     def append(self, text):
         """Write to end of stream while maintaining seek position.
 
@@ -202,9 +216,9 @@ class TeeStdin(TextIOWrapper):
 
         """
         pos = self.tell()
-        self.seek(0, self.SEEK_END)
+        self.seek(0, SEEK_END)
         retval = self._buf.write(text.encode(self.encoding))
-        self.seek(pos, self.SEEK_SET)
+        self.seek(pos, SEEK_SET)
         return retval
 
     def getvalue(self):
@@ -212,6 +226,19 @@ class TeeStdin(TextIOWrapper):
         if self.closed:  # Triggers a ValueError if detached
             self.read()  # Triggers a ValueError
         return self.buffer.peek().decode(self.encoding)
+
+
+class TeeStdin(_Tee, SimulateStdin):
+    """Class to tee simulated contents to a side buffer on read.
+
+    Subclass of :class:`SimulateStdin` and :class:`_Tee` that
+    simulates a stdin stream while teeing all content *read* from the
+    stream to `tee`.
+
+    To emphasize: teeing occurs on content *read*, **not write**..
+
+    As a subclass of :class:`~io.TextIOWrapper`, it is not thread-safe.
+    """
 
 
 class _SafeCloseIOBase(TextIOBase):

--- a/src/stdio_mgr/stdio_mgr.py
+++ b/src/stdio_mgr/stdio_mgr.py
@@ -115,7 +115,7 @@ class TeeStdin(TextIOWrapper):
 
     This class also provides the method
     :meth:`~TeeStdin.append`, which is not available
-    for the base :class:`TextIOWrapper <io.TextIOBase>` type.
+    for the base :class:`TextIOWrapper <io.TextIOWrapper>` type.
     This method adds new content to the end of the
     stream while leaving the read position unchanged.
 
@@ -129,10 +129,8 @@ class TeeStdin(TextIOWrapper):
     `init_text`
 
         |str| *(optional)* --
-        Text to use as the initial contents of the
-        underlying :class:`~io.TextIOWrapper`. `init_text` is
-        passed directly to the :class:~io.TextIOWrapper`
-        instantiation call. Default is an empty |str|.
+        Text to use as the initial contents of the stream to be teed.
+        Default is an empty |str|.
 
     `encoding`
 

--- a/tests/test_stdiomgr_base.py
+++ b/tests/test_stdiomgr_base.py
@@ -40,6 +40,7 @@ except ImportError:
 import pytest
 
 from stdio_mgr import stdio_mgr, StdioManager
+from stdio_mgr.stdio_mgr import _Tee
 
 
 def test_context_manager_instance():
@@ -453,6 +454,14 @@ def test_stdout_access_buffer_after_close(convert_newlines):
         assert convert_newlines("test str\nsecond test str\n") == o.getvalue()
 
     assert convert_newlines("test str\nsecond test str\n") == o.getvalue()
+
+
+def test_tee_type():
+    """Test that incorrect type for Tee.tee raises ValueError."""
+    with pytest.raises(ValueError) as err:
+        _Tee(tee="str", buffer=io.StringIO())
+
+    assert str(err.value) == "tee must be a TextIOBase."
 
 
 @pytest.mark.xfail(reason="Want to ensure 'real' warnings aren't suppressed")

--- a/tox.ini
+++ b/tox.ini
@@ -2,30 +2,14 @@
 minversion=2.0
 isolated_build=True
 envlist=
-    py3{3,4,5,6,7,8}-attrs_{17_4,18_2,19_1}
-    py36-attrs_{17_1,17_2,17_3,18_1,19_1,latest}
-    py3{3,4}-attrs_17_3
-    py3{7,8}-attrs_latest
+    py3{3,4,5,6,7,8}
     sdist_install
 
 [testenv]
 commands=
     pytest -p no:warnings
 deps=
-    attrs_17_1:     attrs==17.1
-    attrs_17_2:     attrs==17.2
-    attrs_17_3:     attrs==17.3
-    attrs_17_4:     attrs==17.4
-    attrs_18_1:     attrs==18.1
-    attrs_18_2:     attrs==18.2
-    attrs_19_1:     attrs==19.1
-    attrs_latest:   attrs
-
-    attrs_17_1:     pytest==3.2.5
-    attrs_17_{2,3}: pytest==3.4.2
-    attrs_17_4:     pytest
-    attrs_18_{1,2}: pytest
-    attrs_latest:   pytest
+    pytest
 
 [testenv:win]
 platform=win


### PR DESCRIPTION
TeeStdin is only needed when both stdin and stdout are being
programmatically managed.  If only stdin is being mocked, and
stdout should behave normally, the context manager should use
the new lighter SimulateStdin which does not perform a tee.

Also removes attrs dependency, which had few benefits anyhow,
and complicates matters when building a deep class hierarchy.

Related to https://github.com/bskinn/stdio-mgr/issues/4