### PR TITLE
DEV: Remove ._buf on RandomTextIO

### DIFF
--- a/src/stdio_mgr/stdio_mgr.py
+++ b/src/stdio_mgr/stdio_mgr.py
@@ -82,8 +82,7 @@ class RandomTextIO(TextIOWrapper):
     def __init__(self):
         """Initialise buffer with utf-8 encoding."""
         self._stream = _PersistedBytesIO(self._set_closed_buf)
-        self._buf = BufferedRandom(self._stream)
-        super().__init__(self._buf, encoding="utf-8")
+        super().__init__(BufferedRandom(self._stream), encoding="utf-8")
 
     def write(self, *args, **kwargs):
         """Flush after each write."""

--- a/tests/test_stdiomgr_base.py
+++ b/tests/test_stdiomgr_base.py
@@ -468,8 +468,6 @@ def test_stdout_detached(convert_newlines):
         f = o.detach()
 
         assert isinstance(f, io.BufferedRandom)
-        assert f is o._buf
-        assert f is i.tee._buf
 
         assert convert_newlines("test str\n") == o.getvalue()
 


### PR DESCRIPTION
No longer needed now that the callback method for persisting the
underlying stream contents is implemented.

The two test asserts for `._buf` have to just be removed, since direct access to
the underlying buffer is no longer available, and thus there is nothing
to compare the detached `f` to.

Closes #67.