### PR TITLE
Fix GitHub URL redirect

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -14,7 +14,7 @@ interactions.
     \(c) Brian Skinn 2018-2019
 
 **Source Repository**
-    http://www.github.com/bskinn/stdio-mgr
+    http://github.com/bskinn/stdio-mgr
 
 **Documentation**
     See README.rst at the GitHub repository

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import os.path as osp
-from setuptools import setup, find_packages
 
+from setuptools import find_packages, setup
 
 with open(osp.join("src", "stdio_mgr", "version.py")) as f:
     exec(f.read())
@@ -18,7 +18,7 @@ setup(
     package_dir={"": "src"},
     provides=["stdio_mgr"],
     python_requires=">=3.4",
-    url="https://www.github.com/bskinn/stdio-mgr",
+    url="https://github.com/bskinn/stdio-mgr",
     license="MIT License",
     author="Brian Skinn",
     author_email="bskinn@alum.mit.edu",

--- a/src/stdio_mgr/__init__.py
+++ b/src/stdio_mgr/__init__.py
@@ -14,7 +14,7 @@ interactions.
     \(c) Brian Skinn 2018-2019
 
 **Source Repository**
-    http://www.github.com/bskinn/stdio-mgr
+    http://github.com/bskinn/stdio-mgr
 
 **Documentation**
     See README.rst at the GitHub repository

--- a/src/stdio_mgr/stdio_mgr.py
+++ b/src/stdio_mgr/stdio_mgr.py
@@ -14,7 +14,7 @@ interactions.
     \(c) Brian Skinn 2018-2019
 
 **Source Repository**
-    http://www.github.com/bskinn/stdio-mgr
+    http://github.com/bskinn/stdio-mgr
 
 **Documentation**
     See README.rst at the GitHub repository

--- a/src/stdio_mgr/version.py
+++ b/src/stdio_mgr/version.py
@@ -14,7 +14,7 @@ interactions.
     \(c) Brian Skinn 2018-2019
 
 **Source Repository**
-    http://www.github.com/bskinn/stdio-mgr
+    http://github.com/bskinn/stdio-mgr
 
 **Documentation**
     See README.rst at the GitHub repository

--- a/tests/micropython/test_micropython.py
+++ b/tests/micropython/test_micropython.py
@@ -14,7 +14,7 @@ interactions.
     \(c) Brian Skinn 2018-2019
 
 **Source Repository**
-    http://www.github.com/bskinn/stdio-mgr
+    http://github.com/bskinn/stdio-mgr
 
 **Documentation**
     See README.rst at the GitHub repository

--- a/tests/test_stdiomgr_base.py
+++ b/tests/test_stdiomgr_base.py
@@ -14,7 +14,7 @@ interactions.
     \(c) Brian Skinn 2018-2019
 
 **Source Repository**
-    http://www.github.com/bskinn/stdio-mgr
+    http://github.com/bskinn/stdio-mgr
 
 **Documentation**
     See README.rst at the GitHub repository


### PR DESCRIPTION
Corrects the GitHub URL to remove 'www.' from the start, as the
inclusion causes unnecessary redirects.

GitHub's standard URL format doesn't include 'www.'
